### PR TITLE
Revert "build(deps): bump com.android.application from 8.6.1 to 8.7.0…

### DIFF
--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.7.0' apply false
+    id "com.android.application" version '8.6.1' apply false
     // use a Kotlin version that is compatible with MapLibre
     id "org.jetbrains.kotlin.android" version "2.0.20" apply false
 }


### PR DESCRIPTION
… in /example/android (#61)"

This reverts commit cc36e7516efb8b518a174c48b8c4d993a47e0e7c.

The project is using an incompatible version (AGP 8.7.0) of the Android Gradle plugin. Latest supported version is AGP 8.6.0