### PR TITLE
feat: Introduced the style loading from assets, json or uri

### DIFF
--- a/android/src/main/kotlin/com/github/josxha/maplibre/MapLibreMapController.kt
+++ b/android/src/main/kotlin/com/github/josxha/maplibre/MapLibreMapController.kt
@@ -158,24 +158,33 @@ class MapLibreMapController(
     private fun getStyle(styleString: String): Style.Builder? {
         val style = styleString.trim();
 
-        // Check if json, uri, absolute path or asset path:
-        if (style == null || style.isEmpty()) {
+        // Check if style is null or empty.
+        if (style.isEmpty()) {
             Log.e("MapLibreMapController", "getStyle - string empty or null");
-        } else if (style.startsWith("{") || style.startsWith("[")) {
-            return Style.Builder().fromJson(style);
-        } else if (style.startsWith("/")) {
-            // Absolute path.
-            return Style.Builder().fromUri("file://" + style);
-        } else if (!style.startsWith("http://")
-            && !style.startsWith("https://")
-            && !style.startsWith("mapbox://")) {
-            // We are assuming that the style will be loaded from an asset here.
-            val key = flutterAssets.getAssetFilePathByName(style);
-            return Style.Builder().fromUri("asset://" + key);
-        } else {
-            return Style.Builder().fromUri(style);
+            return null;
         }
         
+        // Returns the Style based on its type.
+        return when {
+            // JSON style objects
+            style.startsWith("{") || style.startsWith("[") -> 
+                Style.Builder().fromJson(style)
+                
+            // Absolute file paths
+            style.startsWith("/") -> 
+                Style.Builder().fromUri("file://" + style)
+                
+            // Asset files (non-URL, non-Mapbox)
+            !style.startsWith("http://") && 
+            !style.startsWith("https://") && 
+            !style.startsWith("mapbox://") -> 
+                Style.Builder().fromUri("asset://" + flutterAssets.getAssetFilePathByName(style))
+                
+            // Remote URIs (HTTP/HTTPS/Mapbox)
+            else -> Style.Builder().fromUri(style)
+        }
+        
+        Log.e("MapLibreMapController", "getStyle - unable to obtain style")
         return null;
     }
 

--- a/android/src/main/kotlin/com/github/josxha/maplibre/MapLibrePlugin.kt
+++ b/android/src/main/kotlin/com/github/josxha/maplibre/MapLibrePlugin.kt
@@ -28,7 +28,6 @@ class MapLibrePlugin :
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         MapLibreRegistry.context = binding.applicationContext
         PermissionManagerHostApi.setUp(binding.binaryMessenger, this)
-        flutterAssets = binding.flutterAssets
         binding
             .platformViewRegistry
             .registerViewFactory(
@@ -38,6 +37,7 @@ class MapLibrePlugin :
                         override fun getLifecycle(): Lifecycle? = lifecycle
                     },
                     binaryMessenger = binding.binaryMessenger,
+                    flutterAssets = binding.flutterAssets,
                 ),
             )
     }
@@ -118,6 +118,7 @@ object FlutterLifecycleAdapter {
 class MapLibreMapFactory(
     private val lifecycleProvider: LifecycleProvider,
     private val binaryMessenger: BinaryMessenger,
+    private val flutterAssets: FlutterPlugin.FlutterAssets,
 ) : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
     override fun create(
         context: Context,
@@ -129,6 +130,7 @@ class MapLibreMapFactory(
             context,
             lifecycleProvider,
             binaryMessenger,
+            flutterAssets,
         )
 }
 

--- a/example/assets/styles/translucent_style.json
+++ b/example/assets/styles/translucent_style.json
@@ -1,0 +1,37 @@
+{
+	"version": 8,
+	"name": "Demo style",
+	"center": [
+		50,
+		10
+	],
+	"zoom": 4,
+	"sources": {
+		"demotiles": {
+			"type": "vector",
+			"url": "https://demotiles.maplibre.org/tiles/tiles.json"
+		}
+	},
+	"sprite": "",
+	"glyphs": "https://orangemug.github.io/font-glyphs/glyphs/{fontstack}/{range}.pbf",
+	"layers": [
+		{
+			"id": "background",
+			"type": "background",
+			"paint": {
+				"background-color": "rgba(255, 255, 255, 0)"
+			}
+		},
+		{
+			"id": "countries",
+			"type": "line",
+			"source": "demotiles",
+			"source-layer": "countries",
+			"paint": {
+				"line-color": "rgba(0, 0, 0, 1)",
+				"line-width": 1,
+				"line-opacity": 1
+			}
+		}
+	]
+}

--- a/example/lib/map_styles.dart
+++ b/example/lib/map_styles.dart
@@ -8,6 +8,7 @@ abstract class MapStyles {
       'https://api.protomaps.com/styles/v2/dark.json?key=$_protomapsKey';
   static const maptilerStreets =
       'https://api.maptiler.com/maps/streets-v2/style.json?key=$_maptilerKey';
+  static const translucentAsset = 'assets/styles/translucent_style.json';
 
   static const _maptilerKey = 'OPCgnZ51sHETbEQ4wnkd';
   static const _protomapsKey = 'a6f9aebb3965458c';

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -30,6 +30,7 @@ dev_dependencies:
 flutter:
   uses-material-design: true
   assets:
+    - assets/styles/
     - assets/geojson/
 
 flutter_launcher_icons:


### PR DESCRIPTION
### Overview
This PR introduces a new `getStyle` method in `MapLibreMapController` that provides flexible style loading capabilities, allowing users to pass various types of style sources to the `styleString` parameter in `MapOptions`.

### New Features

#### Multi-format Style Support
The `getStyle` method intelligently parses and handles different style input formats:

1. **JSON Style Objects** - Direct JSON strings starting with `{`
2. **Remote URIs** - HTTP/HTTPS URLs and Mapbox style URLs
3. **Local Asset Files** - Flutter assets referenced by filename
4. **Absolute File Paths** - Local file system paths starting with `/`

### Implementation Details

- **Flutter Assets Integration**: Passes `flutterAssets` from `MapLibrePlugin` to `MapLibreMapController` for proper asset resolution
- **Error Handling**: Includes null/empty string validation with appropriate logging
- **URI Normalization**: Automatically prefixes file paths with `file://` protocol

### Usage Examples

#### Remote URI
```dart
MapOptions(
  style: 'https://api.maptiler.com/maps/streets-v2/style.json?key=YOUR_API_KEY'
)
```

#### Asset File
```dart
MapOptions(
  style: 'assets/styles/custom_style.json'
)
```

#### JSON Style Object
```dart
MapOptions(
  style: '{"version": 8, "sources": {"osm": {"type": "raster", "tiles": ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"]}}, "layers": [{"id": "osm", "type": "raster", "source": "osm"}]}'
)
```

This enhancement makes the MapLibre Flutter plugin more user-friendly and provides developers with greater flexibility in how they load map styles.