### PR TITLE
chore: bump android integration tests SDK version to 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [ 24, 36 ]
+        api-level: [ 24, 35 ]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -124,7 +124,7 @@ jobs:
           script: cd example && flutter test integration_test/main.dart --timeout=1800s -r expanded --coverage --coverage-package maplibre
       - name: "Run Codecov"
         uses: codecov/codecov-action@v5
-        if: ${{ matrix.api-level == '36' }}
+        if: ${{ matrix.api-level == '35' }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 #  integration-test-web:


### PR DESCRIPTION
- Flutter 3.35.0 removed support for Android versions lower that Android Nougat / SDK version 24. https://medium.com/flutter/whats-new-in-flutter-3-35-c58ef72e3766
- ~~Android 16 (SDK 36) has been released~~ not supported in the ci yet