### PR TITLE
fix: loosen maplibre_ios version constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   geobase: ^1.5.0
   html: ^0.15.4
   jni: ^0.14.2
-  maplibre_ios: 0.3.0
+  maplibre_ios: ^0.3.0
   objective_c: ^8.0.0
   pointer_interceptor: ^0.10.1+2
   url_launcher: ^6.3.0


### PR DESCRIPTION
Package validation found the following potential issue:
* Your dependency on "maplibre_ios" should allow more than one version. For example:

  dependencies: maplibre_ios: ^0.3.0

  Constraints that are too tight will make it difficult for people to use your package along with other packages that also depend on "maplibre_ios".