### PR TITLE
fix(ios): Remove plugin declaration for FFI-based maplibre_ios

### DIFF
--- a/maplibre_ios/pubspec.yaml
+++ b/maplibre_ios/pubspec.yaml
@@ -22,11 +22,16 @@ dev_dependencies:
   ffigen: 19.1.0
   very_good_analysis: ^10.0.0
 
-flutter:
-  plugin:
-    platforms:
-      ios:
-        pluginClass: MapLibreIosPlugin
+# flutter:
+#   plugin:
+#     platforms:
+#       ios:
+#         pluginClass: MapLibreIosPlugin
+
+# Note: This package uses FFI (Foreign Function Interface) for iOS integration,
+# not traditional Flutter plugin architecture. The plugin declaration above
+# causes Flutter to generate incorrect plugin registration code.
+# See: https://github.com/josxha/flutter-maplibre/issues/[YOUR_ISSUE_NUMBER]
 
 ffigen:
   name: MapLibreFFi


### PR DESCRIPTION
## Fix iOS Plugin Registration for FFI-based Implementation

### Problem
The `maplibre_ios` package declares itself as a traditional Flutter plugin in `pubspec.yaml`, but uses FFI (Foreign Function Interface) architecture. This causes Flutter to generate plugin registration code that references a non-existent `MapLibreIosPlugin` class.

### Error
Semantic Issue (Xcode): Use of undeclared identifier 'MapLibreIosPlugin'
/ios/Runner/GeneratedPluginRegistrant.m:79:3

### Solution
Removed the plugin declaration from `maplibre_ios/pubspec.yaml` since FFI-based packages don't require traditional plugin registration.

### Changes
- Commented out the `flutter.plugin` section in `maplibre_ios/pubspec.yaml`
- Added explanatory comment about why this change is needed

### Testing
- ✅ iOS build completes successfully
- ✅ Map renders correctly on iOS simulator
- ✅ No impact on Android/Web builds

### Background
This issue affects all users trying to build iOS apps with maplibre 0.3.0. The package uses FFI for direct Dart-to-Swift interop but incorrectly declares itself as a traditional plugin, causing Flutter's build system to generate invalid registration code.

### Checklist
- [x] Tested on iOS simulator/device
- [x] Verified no regression on Android
- [x] Added explanatory comment in code