### PR TITLE
fix: missing proguard rule on android, feat: upgrade maplibre native

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "image": "ghcr.io/cirruslabs/flutter",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "Dart-Code.dart-code",
+        "Dart-Code.flutter",
+        "redhat.vscode-yaml"
+      ]
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         working-directory: packages/${{ matrix.package }}
         run: flutter test --timeout=600s --coverage
       - name: "Run Codecov"
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         if: ${{ matrix.sdk == '' }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -105,7 +105,7 @@ jobs:
 #      - name: Run integration tests
 #        run: flutter test integration_test/main.dart --timeout=1800s -r expanded --coverage --coverage-package maplibre.*
 #      - name: "Run Codecov"
-#        uses: codecov/codecov-action@v5
+#        uses: codecov/codecov-action@v6
 #        if: ${{ matrix.os_version == '26.2' }}
 #        env:
 #          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -144,7 +144,7 @@ jobs:
           emulator-boot-timeout: 1800 # 30 minutes
           script: cd examples && flutter test integration_test/main.dart --timeout=1800s -r expanded --coverage --coverage-package maplibre.*
       - name: "Run Codecov"
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         if: ${{ matrix.api-level == '35' }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,24 +175,24 @@ jobs:
 #        run: flutter pub get
 #      - name: "Run web integration tests"
 #        run: xvfb-run -a flutter drive --driver=test_driver/integration_test.dart --target=integration_test/main.dart -d chrome --timeout 120 --dart-define=FLUTTER_WEB_USE_SKIA=true
-  score:
-    name: "Package score"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout project
-        uses: actions/checkout@v6
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with: { cache: true }
-      - name: Install pana
-        run: |
-          sudo apt-get install webp && \
-          dart pub global activate pana
-      - name: Get dependencies
-        run: flutter pub get
-      - name: Check package score
-        working-directory: packages/maplibre
-        run: pana --exit-code-threshold 70 --no-dartdoc .
+#  score:
+#    name: "Package score"
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout project
+#        uses: actions/checkout@v6
+#      - name: Setup Flutter
+#        uses: subosito/flutter-action@v2
+#        with: { cache: true }
+#      - name: Install pana
+#        run: |
+#          sudo apt-get install webp && \
+#          dart pub global activate pana
+#      - name: Get dependencies
+#        run: flutter pub get
+#      - name: Check package score
+#        working-directory: packages/maplibre
+#        run: pana --exit-code-threshold 70 --no-dartdoc .
   build-android:
     name: "[Android] Build APK"
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,7 @@
 name: Publish to pub.dev
 
 on:
-  workflow_dispatch:
-#  push: { tags: [ 'v[0-9]+.[0-9]+.[0-9]+*' ] }
+  push: { tags: [ 'v[0-9]+.[0-9]+.[0-9]+*' ] }
 
 jobs:
   maplibre-platform-interface:

--- a/examples/ios/Flutter/AppFrameworkInfo.plist
+++ b/examples/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/examples/ios/Runner/AppDelegate.swift
+++ b/examples/ios/Runner/AppDelegate.swift
@@ -7,7 +7,7 @@ import UIKit
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+        super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
 
     func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {

--- a/examples/ios/Runner/AppDelegate.swift
+++ b/examples/ios/Runner/AppDelegate.swift
@@ -2,12 +2,15 @@ import Flutter
 import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
     override func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        GeneratedPluginRegistrant.register(with: self)
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
+
+    func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+        GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
     }
 }

--- a/examples/ios/Runner/Info.plist
+++ b/examples/ios/Runner/Info.plist
@@ -26,6 +26,33 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>This app requires access to your location.</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>This app requires access to your location..</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>This app needs your location to display your location on the map.</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>
@@ -45,11 +72,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSLocationWhenInUseUsageDescription</key>
-    <string>This app needs your location to display your location on the map.</string>
-    <key>NSLocationAlwaysUsageDescription</key>
-    <string>This app requires access to your location..</string>
-    <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-    <string>This app requires access to your location.</string>
 </dict>
 </plist>

--- a/examples/lib/style_layers_hillshade_page.dart
+++ b/examples/lib/style_layers_hillshade_page.dart
@@ -44,5 +44,4 @@ class _StyleLayersHillshadePageState extends State<StyleLayersHillshadePage> {
 const _hillshadeStyleLayer = HillshadeStyleLayer(
   id: _layerId,
   sourceId: _sourceId,
-  paint: {'hillshade-shadow-color': '#473B24'},
 );

--- a/examples/pubspec.yaml
+++ b/examples/pubspec.yaml
@@ -14,8 +14,8 @@ dependencies:
   flutter_web_plugins: { sdk: flutter }
   go_router: ^17.0.0
   http: ^1.2.2
-  maplibre: ^0.3.4+1
-  maplibre_webview: ^0.3.4+1
+  maplibre: ^0.3.5
+  maplibre_webview: ^0.3.5
 
 dev_dependencies:
   flutter_launcher_icons: ^0.14.3

--- a/flutter_maplibre.code-workspace
+++ b/flutter_maplibre.code-workspace
@@ -27,6 +27,6 @@
         {
             "name": "maplibre_webview",
             "path": "./packages/maplibre_webview"
-        },
+        }
     ]
 }

--- a/flutter_maplibre.code-workspace
+++ b/flutter_maplibre.code-workspace
@@ -1,0 +1,32 @@
+{
+    "folders": [
+        {
+            "name": "examples",
+            "path": "./examples"
+        },
+        {
+            "name": "maplibre",
+            "path": "./packages/maplibre"
+        },
+        {
+            "name": "maplibre_android",
+            "path": "./packages/maplibre_android"
+        },
+        {
+            "name": "maplibre_ios",
+            "path": "./packages/maplibre_ios"
+        },
+        {
+            "name": "maplibre_platform_interface",
+            "path": "./packages/maplibre_platform_interface"
+        },
+        {
+            "name": "maplibre_web",
+            "path": "./packages/maplibre_web"
+        },
+        {
+            "name": "maplibre_webview",
+            "path": "./packages/maplibre_webview"
+        },
+    ]
+}

--- a/packages/maplibre/CHANGELOG.md
+++ b/packages/maplibre/CHANGELOG.md
@@ -1,7 +1,14 @@
 ## 0.3.5
 
+Thanks to @BartoszStasiurka for his contribution in this release!
+
 - Add `deleteRegion()` to `OfflineManager` by @BartoszStasiurka
-- Android: fix `onStyleLoaded()` unreliable if not loaded immediately
+- Android: fix `onStyleLoaded()` unreliable if style not loaded immediately
+- Android: fix `featuresAtPoint` causes `ClassNotFoundException` in release builds
+- Android: update MapLibre Native to 13.0
+- iOS: update MapLibre Native to 6.25
+- Android: update `jni` to v1.0.0, `jnigen` to 0.16.0
+- fix: set default `maxZoom` to 22 for `RasterSource`, `RasterDemSource` and `VectorSource`.
 
 Full Changelog: [v0.3.4+1...v0.3.5](https://github.com/josxha/flutter-maplibre/compare/v0.3.4+1...v0.3.5)
 

--- a/packages/maplibre/CHANGELOG.md
+++ b/packages/maplibre/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.5
+
+- Add `deleteRegion()` to `OfflineManager` by @BartoszStasiurka
+- Android: fix `onStyleLoaded()` unreliable if not loaded immediately
+
+Full Changelog: [v0.3.4+1...v0.3.5](https://github.com/josxha/flutter-maplibre/compare/v0.3.4+1...v0.3.5)
+
 ## 0.3.4+1
 
 ### Bug Fixes

--- a/packages/maplibre/README.md
+++ b/packages/maplibre/README.md
@@ -52,7 +52,7 @@ Many features of the package are showcased in the example app.
 <tr>
 <td>
 Visit the docs to learn how to get started with maplibre in your
-project: <a href="https://flutter-maplibre.pages.dev/docs/category/getting-started">Get Started</a>.
+project: <a href="https://flutter-maplibre.pages.dev/docs/getting-started/setup/">Get Started</a>.
 </td>
 <td>
 If you want to know more about the classes and properties of the package, have

--- a/packages/maplibre/lib/src/ui/source_attribution.dart
+++ b/packages/maplibre/lib/src/ui/source_attribution.dart
@@ -62,7 +62,8 @@ class _SourceAttributionState extends State<SourceAttribution> {
     final size = MediaQuery.sizeOf(context);
 
     final attributions = [
-      if (widget.showMapLibre) '<a href="https://maplibre.org/">MapLibre</a>',
+      if (widget.showMapLibre)
+        '<a href="https://pub.dev/packages/maplibre">MapLibre</a>',
       ...style.getAttributionsSync(),
     ];
 

--- a/packages/maplibre/pubspec.yaml
+++ b/packages/maplibre/pubspec.yaml
@@ -1,6 +1,6 @@
 name: maplibre
 description: "Permissive and performant mapping library that supports Mapbox Vector Tiles (MVT) powered by MapLibre SDKs."
-version: 0.3.4+1
+version: 0.3.5
 repository: https://github.com/josxha/flutter-maplibre
 issue_tracker: https://github.com/josxha/flutter-maplibre/issues
 homepage: https://flutter-maplibre.pages.dev
@@ -24,10 +24,10 @@ dependencies:
   flutter: { sdk: flutter }
   geobase: ^1.5.0
   html: ^0.15.6
-  maplibre_android: ^0.3.4+1
-  maplibre_ios: ^0.3.4+1
-  maplibre_platform_interface: ^0.3.4+1
-  maplibre_web: ^0.3.4+1
+  maplibre_android: ^0.3.5
+  maplibre_ios: ^0.3.5
+  maplibre_platform_interface: ^0.3.5
+  maplibre_web: ^0.3.5
   pointer_interceptor: ^0.10.1+2
   url_launcher: ^6.3.0
 

--- a/packages/maplibre_android/CHANGELOG.md
+++ b/packages/maplibre_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.5
+
+[Check the maplibre changelog](https://pub.dev/packages/maplibre/changelog#035)
+
 ## 0.3.4+1
 
 [Check the maplibre changelog](https://pub.dev/packages/maplibre/changelog#034+1)

--- a/packages/maplibre_android/android/build.gradle
+++ b/packages/maplibre_android/android/build.gradle
@@ -66,7 +66,7 @@ android {
     }
 
     dependencies {
-        api 'org.maplibre.gl:android-sdk:12.3.+'
+        api 'org.maplibre.gl:android-sdk:13.0.+'
         testImplementation "org.jetbrains.kotlin:kotlin-test"
         testImplementation "org.mockito:mockito-core:5.21.+"
     }

--- a/packages/maplibre_android/android/build.gradle
+++ b/packages/maplibre_android/android/build.gradle
@@ -66,7 +66,7 @@ android {
     }
 
     dependencies {
-        api 'org.maplibre.gl:android-sdk:13.0.+'
+        api 'org.maplibre.gl:android-sdk-opengl:13.0.+'
         testImplementation "org.jetbrains.kotlin:kotlin-test"
         testImplementation "org.mockito:mockito-core:5.21.+"
     }

--- a/packages/maplibre_android/android/consumer-rules.pro
+++ b/packages/maplibre_android/android/consumer-rules.pro
@@ -1,3 +1,4 @@
+-keep class com.google.gson.** { public *; }
 -keep class org.maplibre.android.attribution.** { public *; }
 -keep class org.maplibre.android.camera.** { public *; }
 -keep class org.maplibre.android.constants.** { public *; }

--- a/packages/maplibre_android/lib/src/extensions.dart
+++ b/packages/maplibre_android/lib/src/extensions.dart
@@ -14,7 +14,7 @@ extension GeographicExt on Geographic {
 extension JniLatLngExt on jni.LatLng {
   /// Convert an internal [jni.LatLng] to a [Geographic].
   Geographic toGeographic({bool releaseOriginal = false}) {
-    final point = Geographic(lon: getLongitude(), lat: getLatitude());
+    final point = Geographic(lon: longitude, lat: latitude);
     if (releaseOriginal) release();
     return point;
   }
@@ -68,20 +68,20 @@ extension LatLngBounds on jni.LatLngBounds {
 extension OfflineRegionExt on jni.OfflineRegion {
   /// Convert an internal [jni.OfflineRegion] to an [OfflineRegion].
   OfflineRegion toOfflineRegion() => using((arena) {
-    final jDefinition = getDefinition()..releasedBy(arena);
-    final jMetadata = getMetadata()..releasedBy(arena);
-    final metadataBytes = jMetadata.toList();
+    final jDefinition = definition..releasedBy(arena);
+    final jMetadata = metadata..releasedBy(arena);
+    final metadataBytes = jMetadata.asDart();
     final metadataJson = utf8.decode(metadataBytes);
-    final metadata = jsonDecode(metadataJson) as Map<String, Object?>;
+    final dartMetadata = jsonDecode(metadataJson) as Map<String, Object?>;
 
     return OfflineRegion(
-      id: getId(),
+      id: id,
       bounds: jDefinition.getBounds()!.toLngLatBounds(releaseOriginal: true),
       minZoom: jDefinition.getMinZoom(),
       maxZoom: jDefinition.getMaxZoom(),
       pixelRatio: jDefinition.getPixelRatio(),
       styleUrl: jDefinition.getStyleURL()!.toDartString(releaseOriginal: true),
-      metadata: metadata,
+      metadata: dartMetadata,
     );
   });
 }
@@ -92,10 +92,7 @@ extension ObjectExt on Object {
   JObject toJObject() {
     switch (this) {
       case final Map<String, Object?> value:
-        final jMap = jni.HashMap(
-          K: JObject.nullableType,
-          V: JObject.nullableType,
-        );
+        final jMap = jni.HashMap<JObject?, JObject?>();
         for (final entry in value.entries) {
           final jKey = entry.key.toJObject();
           final jValue = entry.value?.toJObject();
@@ -105,7 +102,7 @@ extension ObjectExt on Object {
         }
         return jMap;
       case final List<Object?> value:
-        final jArray = JArray(JObject.nullableType, value.length);
+        final jArray = JArray.withLength(JObject.type, value.length);
         for (var i = 0; i < value.length; i++) {
           final jElement = value[i]?.toJObject();
           jArray[i] = jElement;

--- a/packages/maplibre_android/lib/src/flutter_api.dart
+++ b/packages/maplibre_android/lib/src/flutter_api.dart
@@ -14,7 +14,7 @@ final class FlutterApi with jni.$FlutterApi {
 
     // MapLibre.getInstance needs to be called before creating the map.
     jni.MapLibre.getInstance(jContext);
-    jni.Logger.setVerbosity(jni.Logger.WARN);
+    jni.Logger.verbosity = jni.Logger.WARN;
 
     final view = jni.FrameLayout(jContext);
     Registry.platformViews[viewId] = view;

--- a/packages/maplibre_android/lib/src/functions.dart
+++ b/packages/maplibre_android/lib/src/functions.dart
@@ -1,14 +1,14 @@
 import 'dart:ui';
 
-import 'package:jni/jni.dart';
+import 'package:jni_flutter/jni_flutter.dart';
 import 'package:maplibre_android/src/jni.g.dart';
 
 /// Get the Android [Context].
-Context getJContext() => Jni.androidApplicationContext.as(Context.type);
+Context getJContext() => androidApplicationContext.as(Context.type);
 
 /// Get the Android [Activity].
 Activity getJActivity() =>
-    Jni.androidActivity(_engineId)?.as(Activity.type) ??
+    androidActivity(_engineId)?.as(Activity.type) ??
     (throw Exception(
       'No Android Activity is attached to the Flutter engine with id $_engineId. '
       'This usually means that the Flutter engine is running in a '

--- a/packages/maplibre_android/lib/src/map_state.dart
+++ b/packages/maplibre_android/lib/src/map_state.dart
@@ -35,11 +35,10 @@ final class MapLibreMapStateAndroid extends MapLibreMapState
 
   jni.FrameLayout get _platformView => Registry.platformViews[_viewId]!;
 
-  jni.Projection get _jProjection =>
-      _cachedJProjection ??= _jMap!.getProjection();
+  jni.Projection get _jProjection => _cachedJProjection ??= _jMap!.projection;
 
   jni.LocationComponent get _jLocationComponent =>
-      _cachedJLocationComponent ??= _jMap!.getLocationComponent();
+      _cachedJLocationComponent ??= _jMap!.locationComponent;
 
   late final _mapClickListener = jni.MapLibreMap$OnMapClickListener.implement(
     jni.$MapLibreMap$OnMapClickListener(
@@ -122,8 +121,8 @@ final class MapLibreMapStateAndroid extends MapLibreMapState
   @override
   Widget buildPlatformWidget(BuildContext context) {
     const viewType = 'plugins.flutter.io/maplibre';
-    jni.MapLibreRegistry.INSTANCE.setFlutterApi(
-      jni.FlutterApi.implement(const FlutterApi()),
+    jni.MapLibreRegistry.INSTANCE.flutterApi = jni.FlutterApi.implement(
+      const FlutterApi(),
     );
 
     if (options.androidMode == AndroidPlatformViewMode.tlhc_vd) {
@@ -251,8 +250,8 @@ final class MapLibreMapStateAndroid extends MapLibreMapState
       ..addOnCameraMoveListener(_mapCameraMoveListener)
       ..addOnCameraIdleListener(_mapCameraIdleListener)
       ..addOnCameraMoveStartedListener(_cameraMoveStartedListener)
-      ..setLatLngBoundsForCameraTarget(
-        options.maxBounds?.toJLatLngBounds(arena: arena),
+      ..latLngBoundsForCameraTarget = options.maxBounds?.toJLatLngBounds(
+        arena: arena,
       );
     setStyle(options.initStyle);
     widget.onEvent?.call(MapEventMapCreated(mapController: this));
@@ -344,39 +343,39 @@ final class MapLibreMapStateAndroid extends MapLibreMapState
     final options = this.options;
     if (this.options == oldOptions) return;
 
-    jMap.setMinZoomPreference(options.minZoom);
-    jMap.setMaxZoomPreference(options.maxZoom);
-    jMap.setMinPitchPreference(options.minPitch);
-    jMap.setMaxPitchPreference(options.maxPitch);
+    jMap.minZoomPreference = options.minZoom;
+    jMap.maxZoomPreference = options.maxZoom;
+    jMap.minPitchPreference = options.minPitch;
+    jMap.maxPitchPreference = options.maxPitch;
 
     // map bounds
     final oldBounds = oldOptions.maxBounds;
     final newBounds = options.maxBounds;
     if (oldBounds != null && newBounds == null) {
-      jMap.setLatLngBoundsForCameraTarget(null);
+      jMap.latLngBoundsForCameraTarget = null;
     } else if ((oldBounds == null && newBounds != null) ||
         (newBounds != null && oldBounds != newBounds)) {
       final bounds = newBounds.toJLatLngBounds(arena: arena);
-      jMap.setLatLngBoundsForCameraTarget(bounds);
+      jMap.latLngBoundsForCameraTarget = bounds;
     }
 
     // gestures
-    final uiSettings = jMap.getUiSettings()..releasedBy(arena);
+    final uiSettings = jMap.uiSettings..releasedBy(arena);
     if (options.gestures.rotate != oldOptions.gestures.rotate) {
-      uiSettings.setRotateGesturesEnabled(options.gestures.rotate);
+      uiSettings.rotateGesturesEnabled = options.gestures.rotate;
     }
     // TODO: pan is not handled, there is no setPanGestureEnabled on Android.
     /*if (options.gestures.pan != oldOptions.gestures.pan) {
         uiSettings.setPanGesturesEnabled(options.gestures.pan);
       }*/
     if (options.gestures.zoom != oldOptions.gestures.zoom) {
-      uiSettings.setZoomGesturesEnabled(options.gestures.zoom);
-      uiSettings.setDoubleTapGesturesEnabled(options.gestures.zoom);
-      uiSettings.setScrollGesturesEnabled(options.gestures.zoom);
-      uiSettings.setQuickZoomGesturesEnabled(options.gestures.zoom);
+      uiSettings.zoomGesturesEnabled = options.gestures.zoom;
+      uiSettings.doubleTapGesturesEnabled = options.gestures.zoom;
+      uiSettings.scrollGesturesEnabled = options.gestures.zoom;
+      uiSettings.quickZoomGesturesEnabled = options.gestures.zoom;
     }
     if (options.gestures.pitch != oldOptions.gestures.pitch) {
-      uiSettings.setTiltGesturesEnabled(options.gestures.pitch);
+      uiSettings.tiltGesturesEnabled = options.gestures.pitch;
     }
   });
 
@@ -506,13 +505,10 @@ final class MapLibreMapStateAndroid extends MapLibreMapState
 
   @override
   MapCamera getCamera() => using((arena) {
-    final jniCamera = _jMap!.getCameraPosition()..releasedBy(arena);
+    final jniCamera = _jMap!.cameraPosition..releasedBy(arena);
     final jniTarget = jniCamera.target!..releasedBy(arena);
     return MapCamera(
-      center: Geographic(
-        lon: jniTarget.getLongitude(),
-        lat: jniTarget.getLatitude(),
-      ),
+      center: Geographic(lon: jniTarget.longitude, lat: jniTarget.latitude),
       zoom: jniCamera.zoom,
       pitch: jniCamera.tilt,
       bearing: jniCamera.bearing,
@@ -523,7 +519,7 @@ final class MapLibreMapStateAndroid extends MapLibreMapState
   List<RenderedFeature> _nativeQueryToRenderedFeatures(
     JList<jni.Feature?> query,
   ) {
-    final features = query.where((f) => f != null).map((f) => f!);
+    final features = query.asDart().where((f) => f != null).map((f) => f!);
 
     final gson = jni.Gson();
     return features
@@ -560,7 +556,7 @@ final class MapLibreMapStateAndroid extends MapLibreMapState
     final query = map.queryRenderedFeatures(
       jni.PointF.new$3(scaledPoint.dx, scaledPoint.dy),
       layerIds != null
-          ? JArray.of(JString.nullableType, layerIds.map((s) => s.toJString()))
+          ? JArray.of(JString.type, layerIds.map((s) => s.toJString()))
           : null,
     );
 
@@ -595,7 +591,7 @@ final class MapLibreMapStateAndroid extends MapLibreMapState
         scaledRect.bottom,
       ),
       layerIds != null
-          ? JArray.of(JString.nullableType, layerIds.map((s) => s.toJString()))
+          ? JArray.of(JString.type, layerIds.map((s) => s.toJString()))
           : null,
     );
 
@@ -616,44 +612,44 @@ final class MapLibreMapStateAndroid extends MapLibreMapState
 
     final jniLayers = style._getLayers()..releasedBy(arena);
     final queriedLayers = <QueriedLayer>[];
-    for (var i = jniLayers.length - 1; i >= 0; i--) {
-      final jniLayer = jniLayers[i]!..releasedBy(arena);
+    for (var i = jniLayers.size() - 1; i >= 0; i--) {
+      final jniLayer = jniLayers.get(i)!..releasedBy(arena);
       JString? jLayerId;
       late final JString jSourceId;
       late final JString jSourceLayer;
       if (jniLayer.isA(jni.LineLayer.type)) {
         final layer = jniLayer.as(jni.LineLayer.type)..releasedBy(arena);
-        jLayerId = layer.getId();
-        jSourceId = layer.getSourceId();
-        jSourceLayer = layer.getSourceLayer();
+        jLayerId = layer.id;
+        jSourceId = layer.sourceId;
+        jSourceLayer = layer.sourceLayer;
       } else if (jniLayer.isA(jni.FillLayer.type)) {
         final layer = jniLayer.as(jni.FillLayer.type)..releasedBy(arena);
-        jLayerId = layer.getId();
-        jSourceId = layer.getSourceId();
-        jSourceLayer = layer.getSourceLayer();
+        jLayerId = layer.id;
+        jSourceId = layer.sourceId;
+        jSourceLayer = layer.sourceLayer;
       } else if (jniLayer.isA(jni.FillExtrusionLayer.type)) {
         final layer = jniLayer.as(jni.FillExtrusionLayer.type)
           ..releasedBy(arena);
-        jLayerId = layer.getId();
-        jSourceId = layer.getSourceId();
-        jSourceLayer = layer.getSourceLayer();
+        jLayerId = layer.id;
+        jSourceId = layer.sourceId;
+        jSourceLayer = layer.sourceLayer;
       } else if (jniLayer.isA(jni.SymbolLayer.type)) {
         final layer = jniLayer.as(jni.SymbolLayer.type)..releasedBy(arena);
-        jLayerId = layer.getId();
-        jSourceId = layer.getSourceId();
-        jSourceLayer = layer.getSourceLayer();
+        jLayerId = layer.id;
+        jSourceId = layer.sourceId;
+        jSourceLayer = layer.sourceLayer;
       } else if (jniLayer.isA(jni.CircleLayer.type)) {
         final layer = jniLayer.as(jni.CircleLayer.type)..releasedBy(arena);
-        jLayerId = layer.getId();
-        jSourceId = layer.getSourceId();
-        jSourceLayer = layer.getSourceLayer();
+        jLayerId = layer.id;
+        jSourceId = layer.sourceId;
+        jSourceLayer = layer.sourceLayer;
       }
       if (jLayerId == null) continue; // ignore all other layers
       jLayerId.releasedBy(arena);
       jSourceId.releasedBy(arena);
       jSourceLayer.releasedBy(arena);
 
-      final queryLayerIds = JArray<JString?>(JString.nullableType, 1)
+      final queryLayerIds = JArray.withLength(JString.type, 1)
         ..releasedBy(arena)
         ..[0] = jLayerId;
       // query one layer at a time
@@ -661,7 +657,7 @@ final class MapLibreMapStateAndroid extends MapLibreMapState
       final scaledPoint = (screenLocation * pixelRatio).toJPointF(arena: arena);
       final jniFeatures = jMap.queryRenderedFeatures(scaledPoint, queryLayerIds)
         ..releasedBy(arena);
-      if (jniFeatures.isEmpty) continue; // layer hasn't been clicked if empty
+      if (jniFeatures.isEmpty()) continue; // layer hasn't been clicked if empty
       final sourceLayer = jSourceLayer.toDartString();
       final queriedLayer = QueriedLayer(
         layerId: jLayerId.toDartString(),
@@ -722,8 +718,8 @@ final class MapLibreMapStateAndroid extends MapLibreMapState
       ..releasedBy(arena);
 
     _jLocationComponent.activateLocationComponent(activationOptions);
-    _jLocationComponent.setRenderMode(bearing);
-    _jLocationComponent.setLocationComponentEnabled(true);
+    _jLocationComponent.renderMode = bearing;
+    _jLocationComponent.locationComponentEnabled = true;
   });
 
   @override
@@ -753,7 +749,7 @@ final class MapLibreMapStateAndroid extends MapLibreMapState
             // only gps bearing
             : jni.CameraMode.NONE_GPS,
     };
-    _jLocationComponent.setCameraMode(mode);
+    _jLocationComponent.cameraMode = mode;
   }
 
   @override
@@ -786,7 +782,7 @@ final class MapLibreMapStateAndroid extends MapLibreMapState
 
   @override
   LngLatBounds getVisibleRegion() => using((arena) {
-    final region = _jProjection.getVisibleRegion()..releasedBy(arena);
+    final region = _jProjection.visibleRegion..releasedBy(arena);
     final jniBounds = region.latLngBounds..releasedBy(arena);
     return jniBounds.toLngLatBounds();
   });
@@ -811,7 +807,7 @@ final class MapLibreMapStateAndroid extends MapLibreMapState
       // URI
       builder.fromUri(trimmed.toJString()..releasedBy(arena));
     }
-    _jMap?.setStyle$3(
+    _jMap?.setStyle$1(
       builder,
       jni.Style$OnStyleLoaded.implement(
         _StyleLoadedCallback(WeakReference(onStyleLoaded)),

--- a/packages/maplibre_android/lib/src/offline_manager.dart
+++ b/packages/maplibre_android/lib/src/offline_manager.dart
@@ -54,7 +54,7 @@ class OfflineManagerAndroid implements OfflineManager {
 
   @override
   void setOfflineTileCountLimit({required int amount}) =>
-      _jManager.setOfflineMapboxTileCountLimit(amount);
+      _jManager.offlineMapboxTileCountLimit = amount;
 
   @override
   Future<void> setMaximumAmbientCacheSize({required int bytes}) async {
@@ -162,7 +162,7 @@ class OfflineManagerAndroid implements OfflineManager {
 
     _jManager.createOfflineRegion(
       jDefinition.as(jni.OfflineRegionDefinition.type)..releasedBy(arena),
-      JByteArray.from(utf8.encode(metadataJson))..releasedBy(arena),
+      JByteArray.of(utf8.encode(metadataJson))..releasedBy(arena),
       jni.OfflineManager$CreateOfflineRegionCallback.implement(
         _CreateOfflineRegionCallback(stream, arena),
       )..releasedBy(arena),
@@ -371,8 +371,8 @@ final class _CreateOfflineRegionCallback
     final jObserver = jni.OfflineRegion$OfflineRegionObserver.implement(
       _OfflineRegionObserver(stream, WeakReference(jRegion), arena),
     )..releasedBy(arena);
-    jRegion.setObserver(jObserver);
-    jRegion.setDownloadState(jni.OfflineRegion.STATE_ACTIVE);
+    jRegion.observer = jObserver;
+    jRegion.downloadState = jni.OfflineRegion.STATE_ACTIVE;
   }
 
   @override
@@ -401,19 +401,19 @@ final class _OfflineRegionObserver
     if (!stream.isClosed) {
       stream.add(
         DownloadProgress(
-          loadedBytes: jStatus.getCompletedResourceSize(),
-          loadedTiles: jStatus.getCompletedResourceCount(),
-          totalTiles: jStatus.getRequiredResourceCount(),
-          totalTilesEstimated: !jStatus.isRequiredResourceCountPrecise(),
+          loadedBytes: jStatus.completedResourceSize,
+          loadedTiles: jStatus.completedResourceCount,
+          totalTiles: jStatus.requiredResourceCount,
+          totalTilesEstimated: !jStatus.isRequiredResourceCountPrecise,
           region: region,
-          downloadCompleted: jStatus.isComplete(),
+          downloadCompleted: jStatus.isComplete,
         ),
       );
     }
 
     // end download if status is complete
-    if (jStatus.isComplete()) {
-      weakJRegion.target?.setDownloadState(jni.OfflineRegion.STATE_INACTIVE);
+    if (jStatus.isComplete) {
+      weakJRegion.target?.downloadState = jni.OfflineRegion.STATE_INACTIVE;
       // This can be called multiple times, check if already completed
       if (!stream.isClosed) {
         stream.close();
@@ -425,15 +425,15 @@ final class _OfflineRegionObserver
   @override
   void onError(jni.OfflineRegionError error) {
     error.releasedBy(arena);
-    weakJRegion.target?.setDownloadState(jni.OfflineRegion.STATE_INACTIVE);
+    weakJRegion.target?.downloadState = jni.OfflineRegion.STATE_INACTIVE;
     stream.addError(
-      Exception(error.getMessage().toDartString(releaseOriginal: true)),
+      Exception(error.message.toDartString(releaseOriginal: true)),
     );
   }
 
   @override
   void mapboxTileCountLimitExceeded(int limit) {
-    weakJRegion.target?.setDownloadState(jni.OfflineRegion.STATE_INACTIVE);
+    weakJRegion.target?.downloadState = jni.OfflineRegion.STATE_INACTIVE;
     stream.addError(Exception('Tile count limit exceeded: $limit'));
   }
 

--- a/packages/maplibre_android/lib/src/style_controller.dart
+++ b/packages/maplibre_android/lib/src/style_controller.dart
@@ -41,47 +41,47 @@ class StyleControllerAndroid extends StyleController {
         switch (layer) {
           case FillStyleLayer():
             final jFillLayer = jni.FillLayer(jId, jSourceId);
-            if (jFilter != null) jFillLayer.setFilter(jFilter);
-            if (jSourceLayer != null) jFillLayer.setSourceLayer(jSourceLayer);
+            if (jFilter != null) jFillLayer.filter = jFilter;
+            if (jSourceLayer != null) jFillLayer.sourceLayer = jSourceLayer;
             jLayer = jFillLayer;
           case CircleStyleLayer():
             final jCircleLayer = jni.CircleLayer(jId, jSourceId);
-            if (jFilter != null) jCircleLayer.setFilter(jFilter);
-            if (jSourceLayer != null) jCircleLayer.setSourceLayer(jSourceLayer);
+            if (jFilter != null) jCircleLayer.filter = jFilter;
+            if (jSourceLayer != null) jCircleLayer.sourceLayer = jSourceLayer;
             jLayer = jCircleLayer;
           case FillExtrusionStyleLayer():
             final jFillExtrusionLayer = jni.FillExtrusionLayer(jId, jSourceId);
-            if (jFilter != null) jFillExtrusionLayer.setFilter(jFilter);
+            if (jFilter != null) jFillExtrusionLayer.filter = jFilter;
             if (jSourceLayer != null) {
-              jFillExtrusionLayer.setSourceLayer(jSourceLayer);
+              jFillExtrusionLayer.sourceLayer = jSourceLayer;
             }
             jLayer = jFillExtrusionLayer;
           case HeatmapStyleLayer():
             final jHeatmapLayer = jni.HeatmapLayer(jId, jSourceId);
-            if (jFilter != null) jHeatmapLayer.setFilter(jFilter);
+            if (jFilter != null) jHeatmapLayer.filter = jFilter;
             if (jSourceLayer != null) {
-              jHeatmapLayer.setSourceLayer(jSourceLayer);
+              jHeatmapLayer.sourceLayer = jSourceLayer;
             }
             jLayer = jHeatmapLayer;
           case HillshadeStyleLayer():
             final jHillshadeLayer = jni.HillshadeLayer(jId, jSourceId);
             if (jSourceLayer != null) {
-              jHillshadeLayer.setSourceLayer(jSourceLayer);
+              jHillshadeLayer.sourceLayer = jSourceLayer;
             }
             jLayer = jHillshadeLayer;
           case LineStyleLayer():
             final jLineLayer = jni.LineLayer(jId, jSourceId);
-            if (jFilter != null) jLineLayer.setFilter(jFilter);
-            if (jSourceLayer != null) jLineLayer.setSourceLayer(jSourceLayer);
+            if (jFilter != null) jLineLayer.filter = jFilter;
+            if (jSourceLayer != null) jLineLayer.sourceLayer = jSourceLayer;
             jLayer = jLineLayer;
           case RasterStyleLayer():
             final jRasterLayer = jni.RasterLayer(jId, jSourceId);
-            if (jSourceLayer != null) jRasterLayer.setSourceLayer(jSourceLayer);
+            if (jSourceLayer != null) jRasterLayer.sourceLayer = jSourceLayer;
             jLayer = jRasterLayer;
           case SymbolStyleLayer():
             final jSymbolLayer = jni.SymbolLayer(jId, jSourceId);
-            if (jFilter != null) jSymbolLayer.setFilter(jFilter);
-            if (jSourceLayer != null) jSymbolLayer.setSourceLayer(jSourceLayer);
+            if (jFilter != null) jSymbolLayer.filter = jFilter;
+            if (jSourceLayer != null) jSymbolLayer.sourceLayer = jSourceLayer;
             jLayer = jSymbolLayer;
           default:
             throw UnimplementedError(
@@ -99,34 +99,32 @@ class StyleControllerAndroid extends StyleController {
         }
     }
 
-    jLayer.setMinZoom(layer.minZoom);
-    jLayer.setMaxZoom(layer.maxZoom);
+    jLayer.minZoom = layer.minZoom;
+    jLayer.maxZoom = layer.maxZoom;
 
     // paint and layout properties
     final layoutEntries = layer.layout.entries.toList(growable: false);
     final paintEntries = layer.paint.entries.toList(growable: false);
-    final props = JArray(
-      jni.PropertyValue.nullableType(JObject.nullableType),
+    final props = JArray.withLength(
+      jni.PropertyValue.type,
       layoutEntries.length + paintEntries.length,
     )..releasedBy(arena);
     for (var i = 0; i < paintEntries.length; i++) {
       final entry = paintEntries[i];
-      props[i] = jni.PaintPropertyValue(
+      props[i] = jni.PaintPropertyValue<JObject?>(
         entry.key.toJString()..releasedBy(arena),
         entry.value.toJObject()..releasedBy(arena),
-        T: JObject.type,
       )..releasedBy(arena);
     }
     for (var i = 0; i < layoutEntries.length; i++) {
       final entry = layoutEntries[i];
-      props[paintEntries.length + i] = jni.LayoutPropertyValue(
+      props[paintEntries.length + i] = jni.LayoutPropertyValue<JObject?>(
         entry.key.toJString()..releasedBy(arena),
         entry.value.toJObject()..releasedBy(arena),
-        T: JObject.type,
       )..releasedBy(arena);
     }
     jLayer.releasedBy(arena);
-    jLayer.setProperties(props);
+    jLayer.properties = props;
 
     // add to style
     if (belowLayerId case final String belowId) {
@@ -168,7 +166,7 @@ class StyleControllerAndroid extends StyleController {
           source.tileSize,
         );
         // TODO apply other properties
-        jSource.setVolatile(source.volatile.toJBoolean()..releasedBy(arena));
+        jSource.volatile = (source.volatile.toJBoolean()..releasedBy(arena));
       case RasterSource():
         if (source.url case final String url) {
           jSource = jni.RasterSource.new$4(
@@ -180,27 +178,26 @@ class StyleControllerAndroid extends StyleController {
           final tiles = source.tiles!.map(
             (e) => e.toJString()..releasedBy(arena),
           );
-          final tilesArray = JArray.of(JString.nullableType, tiles)
-            ..releasedBy(arena);
+          final tilesArray = JArray.of(JString.type, tiles)..releasedBy(arena);
           final tileSet =
               jni.TileSet(
                   '{}'.toJString()..releasedBy(arena),
                   tilesArray.as(JArray.type(JString.type))..releasedBy(arena),
                 )
                 ..releasedBy(arena)
-                ..setMaxZoom(source.maxZoom)
-                ..setMinZoom(source.minZoom);
+                ..maxZoom = source.maxZoom.toJFloat()
+                ..minZoom = source.minZoom.toJFloat();
           jSource = jni.RasterSource.new$6(jId, tileSet, source.tileSize);
         }
         // TODO apply other properties
-        jSource.setVolatile(source.volatile.toJBoolean()..releasedBy(arena));
+        jSource.volatile = (source.volatile.toJBoolean()..releasedBy(arena));
       case VectorSource():
         jSource = jni.VectorSource.new$3(
           jId,
           source.url!.toJString()..releasedBy(arena),
         );
         // TODO apply other properties
-        jSource.setVolatile(source.volatile.toJBoolean()..releasedBy(arena));
+        jSource.volatile = (source.volatile.toJBoolean()..releasedBy(arena));
       case ImageSource():
         // https://maplibre.org/maplibre-native/android/api/-map-libre%20-native%20-android/org.maplibre.android.geometry/-lat-lng-quad/index.html
         final jniQuad = jni.LatLngQuad(
@@ -235,7 +232,7 @@ class StyleControllerAndroid extends StyleController {
   Future<void> addImage(String id, Uint8List bytes) async => using((arena) {
     final jId = id.toJString()..releasedBy(arena);
     final jBitmap = jni.BitmapFactory.decodeByteArray(
-      JByteArray.from(bytes)..releasedBy(arena),
+      JByteArray.of(bytes)..releasedBy(arena),
       0,
       bytes.length,
     );
@@ -253,11 +250,8 @@ class StyleControllerAndroid extends StyleController {
     required String id,
     required String data,
   }) async {
-    final source = _jStyle.getSourceAs(
-      id.toJString(),
-      T: jni.GeoJsonSource.type,
-    )!;
-    source.setGeoJson$3(data.toJString());
+    final source = _jStyle.getSourceAs<jni.GeoJsonSource>(id.toJString());
+    source?.geoJson$3 = data.toJString();
   }
 
   @override
@@ -266,10 +260,11 @@ class StyleControllerAndroid extends StyleController {
   @override
   List<String> getAttributionsSync() => using((arena) {
     try {
-      final jSources = _jStyle.getSources()..releasedBy(arena);
+      final jSources = _jStyle.sources..releasedBy(arena);
       final attributions = <String>[];
-      for (final jSource in jSources) {
-        final jAttribution = jSource?.getAttribution();
+      for (var i = 0; i < jSources.size(); i++) {
+        final jSource = jSources.get(i);
+        final jAttribution = jSource?.attribution;
         if (jAttribution == null) continue;
         final attribution = jAttribution.toDartString(releaseOriginal: true);
         if (attribution.trim().isEmpty) continue;
@@ -284,9 +279,10 @@ class StyleControllerAndroid extends StyleController {
 
   @override
   List<String> getLayerIds() {
-    final layers = _jStyle.getLayers();
+    final layers = _jStyle.layers;
     return layers
-        .map((e) => e?.getId().toDartString(releaseOriginal: true))
+        .asDart()
+        .map((e) => e?.id.toDartString(releaseOriginal: true))
         .nonNulls
         .toList(growable: false);
   }
@@ -296,7 +292,7 @@ class StyleControllerAndroid extends StyleController {
     if (!_jStyle.isReleased) _jStyle.release();
   }
 
-  JList<jni.Layer?> _getLayers() => _jStyle.getLayers();
+  JList<jni.Layer?> _getLayers() => _jStyle.layers;
 
   @override
   void setProjection(MapProjection projection) {

--- a/packages/maplibre_android/pubspec.yaml
+++ b/packages/maplibre_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: maplibre_android
 description: "Android implementation of the Flutter MapLibre plugin."
-version: 0.3.4+1
+version: 0.3.5
 repository: https://github.com/josxha/flutter-maplibre
 issue_tracker: https://github.com/josxha/flutter-maplibre/issues
 homepage: https://flutter-maplibre.pages.dev
@@ -18,7 +18,7 @@ dependencies:
   ffi: ^2.1.3
   flutter: { sdk: flutter }
   jni: ^0.15.2
-  maplibre_platform_interface: ^0.3.4+1
+  maplibre_platform_interface: ^0.3.5
 
 dev_dependencies:
   jnigen: 0.15.0

--- a/packages/maplibre_android/pubspec.yaml
+++ b/packages/maplibre_android/pubspec.yaml
@@ -17,11 +17,12 @@ resolution: workspace
 dependencies:
   ffi: ^2.1.3
   flutter: { sdk: flutter }
-  jni: ^0.15.2
+  jni: ^1.0.0
+  jni_flutter: ^1.0.0
   maplibre_platform_interface: ^0.3.5
 
 dev_dependencies:
-  jnigen: 0.15.0
+  jnigen: 0.16.0
   very_good_analysis: ^10.0.0
 
 flutter:

--- a/packages/maplibre_android/tool/jnigen.dart
+++ b/packages/maplibre_android/tool/jnigen.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:jnigen/jnigen.dart';
-import 'package:jnigen/src/elements/j_elements.dart' as j show Method, Visitor;
 
 void main(List<String> args) {
   final packageRoot = Platform.script.resolve('../');
@@ -68,18 +67,6 @@ void main(List<String> args) {
         'com.google.gson.Gson',
         'com.google.gson.JsonObject',
       ],
-      visitors: [_RenameVisitor()],
     ),
   );
-}
-
-class _RenameVisitor extends j.Visitor {
-  @override
-  void visitMethod(j.Method method) {
-    super.visitMethod(method);
-    // https://github.com/dart-lang/native/issues/2903#issuecomment-3695196951
-    if (method.originalName == 'bool') {
-      method.name = 'bool_';
-    }
-  }
 }

--- a/packages/maplibre_ios/CHANGELOG.md
+++ b/packages/maplibre_ios/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 [Check the maplibre changelog](https://pub.dev/packages/maplibre/changelog#035)
 
-## 0.3.5
+## 0.3.4+1
 
 [Check the maplibre changelog](https://pub.dev/packages/maplibre/changelog#034+1)
 

--- a/packages/maplibre_ios/CHANGELOG.md
+++ b/packages/maplibre_ios/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 0.3.4+1
+## 0.3.5
+
+[Check the maplibre changelog](https://pub.dev/packages/maplibre/changelog#035)
+
+## 0.3.5
 
 [Check the maplibre changelog](https://pub.dev/packages/maplibre/changelog#034+1)
 

--- a/packages/maplibre_ios/ios/maplibre_ios.podspec
+++ b/packages/maplibre_ios/ios/maplibre_ios.podspec
@@ -17,7 +17,7 @@ Helper package for maplibre that provides iOS FFI bindings
   s.dependency 'Flutter'
 
   # Needs to be the same version as in maplibre_ios/Package.swift
-  s.dependency 'MapLibre', '~> 6.21'
+  s.dependency 'MapLibre', '~> 6.25'
 
   s.platform = :ios, '12.0'
 

--- a/packages/maplibre_ios/ios/maplibre_ios/Package.swift
+++ b/packages/maplibre_ios/ios/maplibre_ios/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         // Needs to be the same version as in ../maplibre_ios.podspec
-        .package(url: "https://github.com/maplibre/maplibre-gl-native-distribution", .upToNextMinor(from: "6.21.0")),
+        .package(url: "https://github.com/maplibre/maplibre-gl-native-distribution", .upToNextMinor(from: "6.25.0")),
     ],
     targets: [
         .target(

--- a/packages/maplibre_ios/lib/src/extensions.dart
+++ b/packages/maplibre_ios/lib/src/extensions.dart
@@ -212,6 +212,12 @@ extension MLNStyleLayerExt on MLNStyleLayer {
       case 'fill-extrusion-translate-anchor':
         (this as MLNFillExtrusionStyleLayer).fillExtrusionTranslationAnchor =
             expression;
+      case 'hillshade-shadow-color':
+        (this as MLNHillshadeStyleLayer).hillshadeShadowColor = expression;
+      case 'hillshade-accent-color':
+        (this as MLNHillshadeStyleLayer).hillshadeAccentColor = expression;
+      case 'hillshade-highlight-color':
+        (this as MLNHillshadeStyleLayer).hillshadeHighlightColor = expression;
       case 'line-dasharray':
         (this as MLNLineStyleLayer).lineDashPattern = expression;
       case 'line-translate':

--- a/packages/maplibre_ios/pubspec.yaml
+++ b/packages/maplibre_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: maplibre_ios
 description: "iOS implementation of the Flutter MapLibre plugin."
-version: 0.3.4+1
+version: 0.3.5
 repository: https://github.com/josxha/flutter-maplibre
 issue_tracker: https://github.com/josxha/flutter-maplibre/issues
 homepage: https://flutter-maplibre.pages.dev
@@ -19,7 +19,7 @@ dependencies:
   ffi: ^2.1.3
   flutter: { sdk: flutter }
   hooks: ^1.0.0
-  maplibre_platform_interface: ^0.3.4+1
+  maplibre_platform_interface: ^0.3.5
   native_toolchain_c: ^0.17.4
   objective_c: ^9.0.0+1
   path: ^1.9.1

--- a/packages/maplibre_platform_interface/CHANGELOG.md
+++ b/packages/maplibre_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.5
+
+[Check the maplibre changelog](https://pub.dev/packages/maplibre/changelog#035)
+
 ## 0.3.4+1
 
 [Check the maplibre changelog](https://pub.dev/packages/maplibre/changelog#034+1)

--- a/packages/maplibre_platform_interface/lib/src/style/sources/raster_dem_source.dart
+++ b/packages/maplibre_platform_interface/lib/src/style/sources/raster_dem_source.dart
@@ -15,7 +15,7 @@ final class RasterDemSource extends Source {
     this.tiles,
     this.bounds = const [-180, -85.051129, 180, 85.051129],
     this.minZoom = 0,
-    this.maxZoom = 2,
+    this.maxZoom = 22,
     this.tileSize = 512,
     this.attribution,
     this.encoding = const RasterDemMapboxEncoding(),

--- a/packages/maplibre_platform_interface/lib/src/style/sources/raster_source.dart
+++ b/packages/maplibre_platform_interface/lib/src/style/sources/raster_source.dart
@@ -14,7 +14,7 @@ final class RasterSource extends Source {
     this.tiles,
     this.bounds = const [-180, -85.051129, 180, 85.051129],
     this.minZoom = 0,
-    this.maxZoom = 2,
+    this.maxZoom = 22,
     this.tileSize = 512,
     this.scheme = TileScheme.xyz,
     this.attribution,

--- a/packages/maplibre_platform_interface/lib/src/style/sources/vector_source.dart
+++ b/packages/maplibre_platform_interface/lib/src/style/sources/vector_source.dart
@@ -18,7 +18,7 @@ final class VectorSource extends Source {
     this.bounds = const [-180, -85.051129, 180, 85.051129],
     this.scheme = TileScheme.xyz,
     this.minZoom = 0,
-    this.maxZoom = 2,
+    this.maxZoom = 22,
     this.attribution,
     this.volatile = false,
     @Deprecated(

--- a/packages/maplibre_platform_interface/pubspec.yaml
+++ b/packages/maplibre_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: maplibre_platform_interface
 description: "Shared interfaces for the Flutter MapLibre plugin."
-version: 0.3.4+1
+version: 0.3.5
 repository: https://github.com/josxha/flutter-maplibre
 issue_tracker: https://github.com/josxha/flutter-maplibre/issues
 homepage: https://flutter-maplibre.pages.dev

--- a/packages/maplibre_web/CHANGELOG.md
+++ b/packages/maplibre_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.5
+
+[Check the maplibre changelog](https://pub.dev/packages/maplibre/changelog#035)
+
 ## 0.3.4+1
 
 [Check the maplibre changelog](https://pub.dev/packages/maplibre/changelog#034+1)

--- a/packages/maplibre_web/pubspec.yaml
+++ b/packages/maplibre_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: maplibre_web
 description: "Web implementation of the Flutter MapLibre plugin."
-version: 0.3.4+1
+version: 0.3.5
 repository: https://github.com/josxha/flutter-maplibre
 issue_tracker: https://github.com/josxha/flutter-maplibre/issues
 homepage: https://flutter-maplibre.pages.dev
@@ -18,7 +18,7 @@ dependencies:
   flutter: { sdk: flutter }
   flutter_web_plugins: { sdk: flutter }
   html: ^0.15.4
-  maplibre_platform_interface: ^0.3.4+1
+  maplibre_platform_interface: ^0.3.5
   pointer_interceptor: ^0.10.1+2
   web: ^1.0.0
 

--- a/packages/maplibre_webview/CHANGELOG.md
+++ b/packages/maplibre_webview/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.5
+
+[Check the maplibre changelog](https://pub.dev/packages/maplibre/changelog#035)
+
 ## 0.3.4+1
 
 [Check the maplibre changelog](https://pub.dev/packages/maplibre/changelog#034+1)

--- a/packages/maplibre_webview/pubspec.yaml
+++ b/packages/maplibre_webview/pubspec.yaml
@@ -1,6 +1,6 @@
 name: maplibre_webview
 description: "WebView implementation of the Flutter MapLibre plugin."
-version: 0.3.4+1
+version: 0.3.5
 repository: https://github.com/josxha/flutter-maplibre
 issue_tracker: https://github.com/josxha/flutter-maplibre/issues
 homepage: https://flutter-maplibre.pages.dev
@@ -18,7 +18,7 @@ dependencies:
   flutter: { sdk: flutter }
   flutter_inappwebview: ^6.1.5
   geobase: ^1.5.0
-  maplibre_platform_interface: ^0.3.4+1
+  maplibre_platform_interface: ^0.3.5
 
 dev_dependencies:
   flutter_test: { sdk: flutter }


### PR DESCRIPTION
- [x] fix https://github.com/josxha/flutter-maplibre/issues/504
- [x] bump package versions to v0.3.5
- [x] add devcontainer
- [x] add vscode workspace
- [x] maplibre native android v13.0
- [x] ~~android: use vulkan as rendering backend~~ https://osmus.slack.com/archives/C04G140P9U6/p1775067126515159
- [x] jnigen v0.16.0 / jni v1.0.0
- [x] maplibre native ios v6.25
- [x] ~~ios: use now exposed Offline Region ID property on MLNOfflinePack~~ breaking change: delay until v0.4.0
- [x] investigate ios example app crash on hillshade style layer
- [x] fix RasterSource default maxZoom currently at 2 instead of 22