### PR TITLE
fix: Different marker sizes on Android

### DIFF
--- a/packages/maplibre_android/lib/src/style_controller.dart
+++ b/packages/maplibre_android/lib/src/style_controller.dart
@@ -231,11 +231,13 @@ class StyleControllerAndroid extends StyleController {
   @override
   Future<void> addImage(String id, Uint8List bytes) async => using((arena) {
     final jId = id.toJString()..releasedBy(arena);
+    final pixelRatio = PlatformDispatcher.instance.views.first.devicePixelRatio;
+    final targetDensity = (pixelRatio * 160).round();
     final jOptions = jni.BitmapFactory$Options()
       ..releasedBy(arena)
-      ..inScaled = false
-      ..inDensity = 0
-      ..inTargetDensity = 0;
+      ..inScaled = true
+      ..inDensity = 160
+      ..inTargetDensity = targetDensity;
 
     final jBitmap = jni.BitmapFactory.decodeByteArray$1(
       JByteArray.of(bytes)..releasedBy(arena),

--- a/packages/maplibre_android/lib/src/style_controller.dart
+++ b/packages/maplibre_android/lib/src/style_controller.dart
@@ -234,10 +234,17 @@ class StyleControllerAndroid extends StyleController {
   @override
   Future<void> addImage(String id, Uint8List bytes) async => using((arena) {
     final jId = id.toJString()..releasedBy(arena);
-    final jBitmap = jni.BitmapFactory.decodeByteArray(
+    final jOptions = jni.BitmapFactory$Options()
+      ..releasedBy(arena)
+      ..inScaled = false
+      ..inDensity = 0
+      ..inTargetDensity = 0;
+
+    final jBitmap = jni.BitmapFactory.decodeByteArray$1(
       JByteArray.from(bytes)..releasedBy(arena),
       0,
       bytes.length,
+      jOptions,
     );
     if (jBitmap == null) return;
     jBitmap.releasedBy(arena);


### PR DESCRIPTION
It fixes #510 bug. Now the added markers seem to have the same dimensions across all platforms.
