### PR TITLE
chore: fix ios build artifact, limit maplibre native android to 13.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: maplibre-flutter-demo.app
-          path: examples/build/ios/iphoneos/Runner.app
+          path: examples/build/ios/iphonesimulator/Runner.app
   build-web:
     name: "[Web] Build"
     runs-on: ubuntu-latest

--- a/examples/android/settings.gradle.kts
+++ b/examples/android/settings.gradle.kts
@@ -21,7 +21,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.12.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.24" apply false
+    id("org.jetbrains.kotlin.android") version "2.1.21" apply false
     id("org.jlleitschuh.gradle.ktlint") version "14.0.+" apply false
 }
 

--- a/examples/android/settings.gradle.kts
+++ b/examples/android/settings.gradle.kts
@@ -21,7 +21,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.12.0" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.21" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.24" apply false
     id("org.jlleitschuh.gradle.ktlint") version "14.0.+" apply false
 }
 

--- a/packages/maplibre_android/android/build.gradle
+++ b/packages/maplibre_android/android/build.gradle
@@ -66,7 +66,7 @@ android {
     }
 
     dependencies {
-        api 'org.maplibre.gl:android-sdk-opengl:13.0.1'
+        api 'org.maplibre.gl:android-sdk-opengl:13.0.2'
         testImplementation "org.jetbrains.kotlin:kotlin-test"
         testImplementation "org.mockito:mockito-core:5.21.+"
     }

--- a/packages/maplibre_android/android/build.gradle
+++ b/packages/maplibre_android/android/build.gradle
@@ -66,7 +66,7 @@ android {
     }
 
     dependencies {
-        api 'org.maplibre.gl:android-sdk-opengl:13.0.+'
+        api 'org.maplibre.gl:android-sdk-opengl:13.0.1'
         testImplementation "org.jetbrains.kotlin:kotlin-test"
         testImplementation "org.mockito:mockito-core:5.21.+"
     }


### PR DESCRIPTION
13.0.3 causes jnigen to fail (and requires AGP 9?)