### PR TITLE
fix: blurry image icons on high-DPR Android devices

### DIFF
--- a/examples/lib/layers_marker_page.dart
+++ b/examples/lib/layers_marker_page.dart
@@ -49,6 +49,7 @@ class _LayersMarkerPageState extends State<LayersMarkerPage> {
               await event.style.addImageFromIconData(
                 id: 'marker',
                 iconData: Icons.location_on,
+                devicePixelRatio: MediaQuery.of(context).devicePixelRatio,
                 color: Colors.red,
               );
               setState(() {

--- a/packages/maplibre_android/lib/src/style_controller.dart
+++ b/packages/maplibre_android/lib/src/style_controller.dart
@@ -231,19 +231,10 @@ class StyleControllerAndroid extends StyleController {
   @override
   Future<void> addImage(String id, Uint8List bytes) async => using((arena) {
     final jId = id.toJString()..releasedBy(arena);
-    final pixelRatio = PlatformDispatcher.instance.views.first.devicePixelRatio;
-    final targetDensity = (pixelRatio * 160).round();
-    final jOptions = jni.BitmapFactory$Options()
-      ..releasedBy(arena)
-      ..inScaled = true
-      ..inDensity = 160
-      ..inTargetDensity = targetDensity;
-
-    final jBitmap = jni.BitmapFactory.decodeByteArray$1(
+    final jBitmap = jni.BitmapFactory.decodeByteArray(
       JByteArray.of(bytes)..releasedBy(arena),
       0,
       bytes.length,
-      jOptions,
     );
     if (jBitmap == null) return;
     jBitmap.releasedBy(arena);

--- a/packages/maplibre_platform_interface/lib/src/style_controller.dart
+++ b/packages/maplibre_platform_interface/lib/src/style_controller.dart
@@ -110,28 +110,35 @@ abstract class StyleController {
 
   /// Create an image from [IconData] and add it to the map with the given [id].
   ///
-  /// The [size] parameter defines the width and height of the resulting image
-  /// in pixels.
+  /// The [size] parameter defines the logical width and height of the
+  /// resulting image. Use [devicePixelRatio] to scale correctly the icon based
+  /// on the device's screen. You can use [MediaQuery] to retrieve the
+  /// corresponding value.
   ///
   /// The [color] parameter defines the color of the icon. By default, it is
   /// black.
   Future<void> addImageFromIconData({
     required String id,
     required IconData iconData,
-    int size = 200,
+    double size = 200,
+    double devicePixelRatio = 1.0,
     Color color = const Color(0xFF000000),
   }) async {
+    final pixelSize = (devicePixelRatio * size).round();
+    
     await addImageFromCanvas(
       id: id,
-      width: size,
-      height: size,
+      width: pixelSize,
+      height: pixelSize,
       painter: (canvas) {
+        canvas.scale(devicePixelRatio);
+
         TextPainter(textDirection: TextDirection.ltr)
           ..text = TextSpan(
             text: String.fromCharCode(iconData.codePoint),
             style: TextStyle(
               letterSpacing: 0,
-              fontSize: size.toDouble(),
+              fontSize: size,
               fontFamily: iconData.fontFamily,
               package: iconData.fontPackage,
               color: color,

--- a/packages/maplibre_platform_interface/lib/src/style_controller.dart
+++ b/packages/maplibre_platform_interface/lib/src/style_controller.dart
@@ -125,7 +125,7 @@ abstract class StyleController {
     Color color = const Color(0xFF000000),
   }) async {
     final pixelSize = (devicePixelRatio * size).round();
-    
+
     await addImageFromCanvas(
       id: id,
       width: pixelSize,


### PR DESCRIPTION
This PR fixes blurry image icons on Android devices with a high device pixel ratio when adding images with `addImage` or similar. More specifically this PR:

- Reverts #511 which introduced `devicePixelRatio` scaling on physical image bitmaps, which is wrong and can result in blurry images.
- Adds a `devicePixelRatio` argument to the `addImageFromIconData` method so to scale correctly the icon before converting it to byte data.
- Updates the `addImageFromIconData` example file and doc to show how to use `devicePixelRatio`.