### PR TITLE
fix: unify scale and dpi handling between Android & iOS for addImage

### DIFF
--- a/packages/maplibre_android/lib/src/style_controller.dart
+++ b/packages/maplibre_android/lib/src/style_controller.dart
@@ -231,13 +231,8 @@ class StyleControllerAndroid extends StyleController {
   @override
   Future<void> addImage(String id, Uint8List bytes) async => using((arena) {
     final jId = id.toJString()..releasedBy(arena);
-    final pixelRatio = PlatformDispatcher.instance.views.first.devicePixelRatio;
-    final targetDensity = (pixelRatio * 160).round();
     final jOptions = jni.BitmapFactory$Options()
-      ..releasedBy(arena)
-      ..inScaled = true
-      ..inDensity = 160
-      ..inTargetDensity = targetDensity;
+      ..releasedBy(arena);
 
     final jBitmap = jni.BitmapFactory.decodeByteArray$1(
       JByteArray.of(bytes)..releasedBy(arena),

--- a/packages/maplibre_android/lib/src/style_controller.dart
+++ b/packages/maplibre_android/lib/src/style_controller.dart
@@ -231,14 +231,11 @@ class StyleControllerAndroid extends StyleController {
   @override
   Future<void> addImage(String id, Uint8List bytes) async => using((arena) {
     final jId = id.toJString()..releasedBy(arena);
-    final jOptions = jni.BitmapFactory$Options()
-      ..releasedBy(arena);
 
-    final jBitmap = jni.BitmapFactory.decodeByteArray$1(
+    final jBitmap = jni.BitmapFactory.decodeByteArray(
       JByteArray.of(bytes)..releasedBy(arena),
       0,
-      bytes.length,
-      jOptions,
+      bytes.length
     );
     if (jBitmap == null) return;
     jBitmap.releasedBy(arena);

--- a/packages/maplibre_ios/lib/src/map_state.dart
+++ b/packages/maplibre_ios/lib/src/map_state.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:ffi';
+import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -8,8 +9,6 @@ import 'package:maplibre_ios/src/extensions.dart';
 import 'package:maplibre_ios/src/maplibre_ffi.g.dart';
 import 'package:maplibre_platform_interface/maplibre_platform_interface.dart';
 import 'package:objective_c/objective_c.dart';
-import 'dart:ui';
-
 
 part 'style_controller.dart';
 

--- a/packages/maplibre_ios/lib/src/map_state.dart
+++ b/packages/maplibre_ios/lib/src/map_state.dart
@@ -8,6 +8,8 @@ import 'package:maplibre_ios/src/extensions.dart';
 import 'package:maplibre_ios/src/maplibre_ffi.g.dart';
 import 'package:maplibre_platform_interface/maplibre_platform_interface.dart';
 import 'package:objective_c/objective_c.dart';
+import 'dart:ui';
+
 
 part 'style_controller.dart';
 

--- a/packages/maplibre_ios/lib/src/style_controller.dart
+++ b/packages/maplibre_ios/lib/src/style_controller.dart
@@ -8,7 +8,8 @@ class StyleControllerIos extends StyleController {
 
   @override
   Future<void> addImage(String id, Uint8List bytes) async {
-    final image = UIImage.imageWithData(bytes.toNSData());
+    final pixelRatio = PlatformDispatcher.instance.views.first.devicePixelRatio;
+    final image = UIImage.imageWithData$1(bytes.toNSData(), scale: pixelRatio);
     if (image == null) return;
     _ffiStyle.setImage(image, forName: id.toNSString());
   }

--- a/packages/maplibre_ios/lib/src/style_controller.dart
+++ b/packages/maplibre_ios/lib/src/style_controller.dart
@@ -8,7 +8,7 @@ class StyleControllerIos extends StyleController {
 
   @override
   Future<void> addImage(String id, Uint8List bytes) async {
-    final pixelRatio = PlatformDispatcher.instance.views.first.devicePixelRatio;
+    final pixelRatio = PlatformDispatcher.instance.views.firstOrNull?.devicePixelRatio ?? 1.0;
     final image = UIImage.imageWithData$1(bytes.toNSData(), scale: pixelRatio);
     if (image == null) return;
     _ffiStyle.setImage(image, forName: id.toNSString());


### PR DESCRIPTION
Given that  `addImageFromWidget` in `maplibre_platform_interface/lib/src/style_controller` already computes logical and physical image size, we don't need additional calculation for Android. 

On iOS, we need to set the scale of the image from the device pixel ratio.

This will result in the same image size and resolution on both Android and iOS. The rendered size on the map will be the same as rendering the widget directly using Flutter. 

This is similar to #522 but for rendering widgets and also fixing the functionality for iOS.

Co-authored-by: sszajbely <44438989+sszajbely@users.noreply.github.com>
Closes #499 