### PR TITLE
Fixes #542: resolve GeoJSON rendering failure in obfuscated releas…

### DIFF
--- a/packages/maplibre_android/android/consumer-rules.pro
+++ b/packages/maplibre_android/android/consumer-rules.pro
@@ -1,21 +1,2 @@
--keep class com.google.gson.** { public *; }
--keep class org.maplibre.android.attribution.** { public *; }
--keep class org.maplibre.android.camera.** { public *; }
--keep class org.maplibre.android.constants.** { public *; }
--keep class org.maplibre.android.exceptions.** { public *; }
--keep class org.maplibre.android.geometry.** { public *; }
--keep class org.maplibre.android.http.** { public *; }
--keep class org.maplibre.android.location.** { public *; }
--keep class org.maplibre.android.log.** { public *; }
--keep class org.maplibre.android.maps.** { public *; }
--keep class org.maplibre.android.offline.** { public *; }
--keep class org.maplibre.android.storage.** { public *; }
--keep class org.maplibre.android.style.layers.** { public *; }
--keep class org.maplibre.android.style.light.** { public *; }
--keep class org.maplibre.android.style.sources.** { public *; }
--keep class org.maplibre.android.style.types.** { public *; }
--keep class org.maplibre.android.text.** { public *; }
--keep class org.maplibre.android.util.** { public *; }
--keep class org.maplibre.android.utils.** { public *; }
--keep class org.maplibre.geojson.** { public *; }
--keep class io.flutter.plugin.platform.** { public *; }
+-keep class com.google.gson.** { *; }
+-keep class org.maplibre.** { *; }


### PR DESCRIPTION
Fixes #542 
…e builds

- Updated `consumer-rules.pro` in `maplibre_android` to preserve all members (`*;`) of `org.maplibre.**` and `com.google.gson.**` instead of just `public *;`.
- Prevents R8/ProGuard from aggressively stripping and obfuscating internal package-private classes (like `AutoValue_Feature`) and private fields critical for Gson reflection.
- Fixes a silent failure where GeoJSON points and lines completely disappeared from the map in production builds.
- Updated `README.md` to include commands for testing obfuscated release builds locally via APK.