### PR TITLE
fix(android): make camera listeners non-blocking

### DIFF
--- a/packages/maplibre/CHANGELOG.md
+++ b/packages/maplibre/CHANGELOG.md
@@ -1,3 +1,10 @@
+## unreleased
+
+### Bug Fixes
+
+- Android: camera listeners no longer block the calling Java thread on every
+  camera event.
+
 ## 0.3.5
 
 This release contains a couple of bug fixes and improvements.

--- a/packages/maplibre_android/lib/src/jni.g.dart
+++ b/packages/maplibre_android/lib/src/jni.g.dart
@@ -31203,7 +31203,8 @@ final class $URL$Type$ extends jni$_.JType<URL> {
 /// from: `java.util.HashMap`
 extension type HashMap<$K extends jni$_.JObject?, $V extends jni$_.JObject?>._(
   jni$_.JObject _$this
-) implements AbstractMap, Cloneable, jni$_.JMap<$K?, $V?>, Serializable {
+)
+    implements AbstractMap, Cloneable, jni$_.JMap<$K?, $V?>, Serializable {
   static final _class = jni$_.JClass.forName(r'java/util/HashMap');
 
   /// The type which includes information such as the signature of this class.
@@ -32232,7 +32233,8 @@ final class $HashMap$Type$ extends jni$_.JType<HashMap> {
 /// from: `io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding$OnSaveInstanceStateListener`
 extension type ActivityPluginBinding$OnSaveInstanceStateListener._(
   jni$_.JObject _$this
-) implements jni$_.JObject {
+)
+    implements jni$_.JObject {
   static final _class = jni$_.JClass.forName(
     r'io/flutter/embedding/engine/plugins/activity/ActivityPluginBinding$OnSaveInstanceStateListener',
   );
@@ -33848,7 +33850,8 @@ final class $PluginRegistry$NewIntentListener$Type$
 /// from: `io.flutter.plugin.common.PluginRegistry$RequestPermissionsResultListener`
 extension type PluginRegistry$RequestPermissionsResultListener._(
   jni$_.JObject _$this
-) implements jni$_.JObject {
+)
+    implements jni$_.JObject {
   static final _class = jni$_.JClass.forName(
     r'io/flutter/plugin/common/PluginRegistry$RequestPermissionsResultListener',
   );
@@ -45891,7 +45894,8 @@ final class $LocationComponent$Type$ extends jni$_.JType<LocationComponent> {
 /// from: `org.maplibre.android.location.LocationComponentActivationOptions$Builder`
 extension type LocationComponentActivationOptions$Builder._(
   jni$_.JObject _$this
-) implements jni$_.JObject {
+)
+    implements jni$_.JObject {
   static final _class = jni$_.JClass.forName(
     r'org/maplibre/android/location/LocationComponentActivationOptions$Builder',
   );
@@ -64897,7 +64901,8 @@ final class $MapView$OnCameraWillChangeListener$Type$
 /// from: `org.maplibre.android.maps.MapView$OnCanRemoveUnusedStyleImageListener`
 extension type MapView$OnCanRemoveUnusedStyleImageListener._(
   jni$_.JObject _$this
-) implements jni$_.JObject {
+)
+    implements jni$_.JObject {
   static final _class = jni$_.JClass.forName(
     r'org/maplibre/android/maps/MapView$OnCanRemoveUnusedStyleImageListener',
   );
@@ -65852,7 +65857,8 @@ final class $MapView$OnDidFinishRenderingFrameListener$Type$
 /// from: `org.maplibre.android.maps.MapView$OnDidFinishRenderingFrameWithStatsListener`
 extension type MapView$OnDidFinishRenderingFrameWithStatsListener._(
   jni$_.JObject _$this
-) implements jni$_.JObject {
+)
+    implements jni$_.JObject {
   static final _class = jni$_.JClass.forName(
     r'org/maplibre/android/maps/MapView$OnDidFinishRenderingFrameWithStatsListener',
   );
@@ -83443,7 +83449,8 @@ final class $MapLibreGLSurfaceView$Type$
 /// from: `org.maplibre.android.maps.renderer.surfaceview.MapLibreSurfaceView$OnSurfaceViewDetachedListener`
 extension type MapLibreSurfaceView$OnSurfaceViewDetachedListener._(
   jni$_.JObject _$this
-) implements jni$_.JObject {
+)
+    implements jni$_.JObject {
   static final _class = jni$_.JClass.forName(
     r'org/maplibre/android/maps/renderer/surfaceview/MapLibreSurfaceView$OnSurfaceViewDetachedListener',
   );
@@ -86298,7 +86305,8 @@ final class $OfflineManager$Companion$Type$
 /// from: `org.maplibre.android.offline.OfflineManager$CreateOfflineRegionCallback`
 extension type OfflineManager$CreateOfflineRegionCallback._(
   jni$_.JObject _$this
-) implements jni$_.JObject {
+)
+    implements jni$_.JObject {
   static final _class = jni$_.JClass.forName(
     r'org/maplibre/android/offline/OfflineManager$CreateOfflineRegionCallback',
   );
@@ -87162,7 +87170,8 @@ final class $OfflineManager$ListOfflineRegionsCallback$Type$
 /// from: `org.maplibre.android.offline.OfflineManager$MergeOfflineRegionsCallback`
 extension type OfflineManager$MergeOfflineRegionsCallback._(
   jni$_.JObject _$this
-) implements jni$_.JObject {
+)
+    implements jni$_.JObject {
   static final _class = jni$_.JClass.forName(
     r'org/maplibre/android/offline/OfflineManager$MergeOfflineRegionsCallback',
   );
@@ -88313,7 +88322,8 @@ final class $OfflineRegion$OfflineRegionDeleteCallback$Type$
 /// from: `org.maplibre.android.offline.OfflineRegion$OfflineRegionInvalidateCallback`
 extension type OfflineRegion$OfflineRegionInvalidateCallback._(
   jni$_.JObject _$this
-) implements jni$_.JObject {
+)
+    implements jni$_.JObject {
   static final _class = jni$_.JClass.forName(
     r'org/maplibre/android/offline/OfflineRegion$OfflineRegionInvalidateCallback',
   );
@@ -88998,7 +89008,8 @@ final class $OfflineRegion$OfflineRegionStatusCallback$Type$
 /// from: `org.maplibre.android.offline.OfflineRegion$OfflineRegionUpdateMetadataCallback`
 extension type OfflineRegion$OfflineRegionUpdateMetadataCallback._(
   jni$_.JObject _$this
-) implements jni$_.JObject {
+)
+    implements jni$_.JObject {
   static final _class = jni$_.JClass.forName(
     r'org/maplibre/android/offline/OfflineRegion$OfflineRegionUpdateMetadataCallback',
   );
@@ -90656,7 +90667,8 @@ final class $OfflineRegionStatus$Type$
 /// from: `org.maplibre.android.offline.OfflineTilePyramidRegionDefinition$Companion`
 extension type OfflineTilePyramidRegionDefinition$Companion._(
   jni$_.JObject _$this
-) implements jni$_.JObject {
+)
+    implements jni$_.JObject {
   static final _class = jni$_.JClass.forName(
     r'org/maplibre/android/offline/OfflineTilePyramidRegionDefinition$Companion',
   );
@@ -105523,7 +105535,8 @@ final class $Layer$Type$ extends jni$_.JType<Layer> {
 /// from: `org.maplibre.android.style.layers.LayoutPropertyValue`
 extension type LayoutPropertyValue<$T extends jni$_.JObject?>._(
   jni$_.JObject _$this
-) implements PropertyValue<$T?> {
+)
+    implements PropertyValue<$T?> {
   static final _class = jni$_.JClass.forName(
     r'org/maplibre/android/style/layers/LayoutPropertyValue',
   );
@@ -107063,7 +107076,8 @@ final class $LineLayer$Type$ extends jni$_.JType<LineLayer> {
 /// from: `org.maplibre.android.style.layers.PaintPropertyValue`
 extension type PaintPropertyValue<$T extends jni$_.JObject?>._(
   jni$_.JObject _$this
-) implements PropertyValue<$T?> {
+)
+    implements PropertyValue<$T?> {
   static final _class = jni$_.JClass.forName(
     r'org/maplibre/android/style/layers/PaintPropertyValue',
   );
@@ -138127,7 +138141,8 @@ final class $ViewManager$Type$ extends jni$_.JType<ViewManager> {
 ///
 extension type LayoutAnimationController$$AnimationParameters._(
   jni$_.JObject _$this
-) implements jni$_.JObject {
+)
+    implements jni$_.JObject {
   static const jni$_.JType<LayoutAnimationController$$AnimationParameters>
   type = $LayoutAnimationController$$AnimationParameters$Type$();
 }

--- a/packages/maplibre_android/lib/src/map_state.dart
+++ b/packages/maplibre_android/lib/src/map_state.dart
@@ -82,6 +82,7 @@ final class MapLibreMapStateAndroid extends MapLibreMapState
               widget.onEvent?.call(MapEventMoveCamera(camera: mapCamera));
             }
           }),
+          onCameraMove$async: true,
         ),
       );
   late final _mapCameraIdleListener =
@@ -90,6 +91,7 @@ final class MapLibreMapStateAndroid extends MapLibreMapState
           onCameraIdle: () => using((arena) {
             widget.onEvent?.call(const MapEventCameraIdle());
           }),
+          onCameraIdle$async: true,
         ),
       );
   late final _cameraMoveStartedListener =
@@ -112,6 +114,7 @@ final class MapLibreMapStateAndroid extends MapLibreMapState
             if (moveReason == null) return;
             widget.onEvent?.call(MapEventStartMoveCamera(reason: moveReason));
           }),
+          onCameraMoveStarted$async: true,
         ),
       );
 


### PR DESCRIPTION
### Description

On Android, the three camera listeners are implemented without jnigen's `$async` flag:
`MapLibreMap$OnCameraMoveListener.onCameraMove`, `MapLibreMap$OnCameraIdleListener.onCameraIdle`
and `MapLibreMap$OnCameraMoveStartedListener.onCameraMoveStarted` in
`maplibre_android/lib/src/map_state.dart`.

Every camera event therefore makes the calling Java thread (`CameraChangeDispatcher`) wait until
the Dart callback has returned. That callback is not cheap: `onCameraMove` calls `getCamera()`,
which goes back into Java and allocates, then `setState()`, which triggers a full Flutter rebuild.
Under a continuous camera feed (location tracking, animated camera) this happens on every frame.

To be explicit about scope, since it points the other way from #219 and the first line of #402:
this is about the **Java to Dart** direction only. Dart to Java calls stay synchronous, which is
the package's deliberate choice, and nothing here asks to change that.

### Why these three specifically

jnigen only emits a `<method>$async` flag for methods returning `void`, so the flag's presence in
the generated bindings is an objective eligibility criterion. `jni.g.dart` does declare
`onCameraMove$async`, `onCameraIdle$async` and `onCameraMoveStarted$async`, each defaulting to
`false`. The package already relies on this mechanism in 21 places (the `CancelableCallback` pair
and the offline callbacks), so the pattern is established; these three were simply left out.

### The change

Three lines, one per listener:

```dart
jni.MapLibreMap$OnCameraMoveListener.implement(
  jni.$MapLibreMap$OnCameraMoveListener(
    onCameraMove: () => using((arena) { /* unchanged */ }),
    onCameraMove$async: true,
  ),
)
```

None of the three callbacks returns a value, so nothing depends on the round trip completing.

### Notes

- This does not reduce the work done per event: `getCamera()` and `setState()` still run on every
  camera event. It only stops the Java dispatcher from waiting for them. Cutting the per-event
  cost is a separate discussion.
- The same bridge has already produced a field bug once, #479 (use-after-release on
  `onCameraMove`, fixed by the disposal guards in #481). Different failure mode, but the stack
  trace there shows this path is hot under a continuous camera feed.
- We have had the three-line change running in a fork, in a real app, since 2026-07-30, and the
  ANR signature we were chasing is gone. We no longer have the raw traces at hand, so please take
  that as a report rather than as data.
