### PR TITLE
fix(layers): skip re-serialising a GeoJSON source whose layer is unchanged

### DIFF
--- a/packages/maplibre_platform_interface/lib/src/layer/layer_manager.dart
+++ b/packages/maplibre_platform_interface/lib/src/layer/layer_manager.dart
@@ -38,12 +38,21 @@ class LayerManager {
       final layer = layers[index];
       final oldLayer = index > _oldLayers.length - 1 ? null : _oldLayers[index];
       // update source
-      // TODO check if the entities of both lists are equal
       if (oldLayer case Layer()) {
-        style.updateGeoJsonSource(
-          id: layer.getSourceId(index),
-          data: FeatureCollection(layer.list).toText(),
-        );
+        // Only re-serialise a source whose layer actually changed. Building
+        // the FeatureCollection text is the expensive half of this call, and
+        // it ran on every rebuild for every layer even when nothing about the
+        // layer had moved.
+        //
+        // `Layer.==` is the same test already applied to the style layer a few
+        // lines below, so this uses one condition rather than introducing a
+        // second notion of "changed".
+        if (layer != oldLayer) {
+          style.updateGeoJsonSource(
+            id: layer.getSourceId(index),
+            data: FeatureCollection(layer.list).toText(),
+          );
+        }
       } else {
         final source = GeoJsonSource(
           id: layer.getSourceId(index),


### PR DESCRIPTION
Resolves the `// TODO check if the entities of both lists are equal` in `LayerManager.updateLayers()`.

## The problem

`updateLayers()` calls `style.updateGeoJsonSource()` for **every** layer on **every** rebuild:

```dart
// update source
// TODO check if the entities of both lists are equal
if (oldLayer case Layer()) {
  style.updateGeoJsonSource(
    id: layer.getSourceId(index),
    data: FeatureCollection(layer.list).toText(),
  );
}
```

`FeatureCollection(layer.list).toText()` is the expensive half of that call — it serialises the whole feature list to JSON and hands it across the platform channel to be parsed natively again. For a layer that has not changed, all of that work is discarded on the other side.

It shows up on any app that rebuilds the map frequently with a large, mostly-static layer. In my case a cycling app draws a planned route as a `LineLayer` and rebuilds on each GPS fix — so the full route was being re-serialised roughly once a second, for an entire ride, to produce a byte-identical payload.

## The change

Reuse the test the surrounding code already applies. `Layer.==` guards the **style layer** update a few lines below; this applies the same condition to the **source** update, which is what the TODO asked for:

```dart
if (layer != oldLayer) {
  style.updateGeoJsonSource(...);
}
```

One notion of "changed" rather than two.

## What it deliberately does not do

`Layer.==` compares `list == other.list`, and for a plain `List` that is **identity**. So a source is skipped only when the caller hands back the *same list instance* — a caller that rebuilds an equal-but-new list still re-serialises exactly as before.

That is conservative on purpose: **nothing that genuinely changed can be skipped**, and the benefit goes to callers that already cache their layer list. A deeper element-wise comparison would help more callers, but on a large feature list it costs a full walk per rebuild, which is the thing being avoided — so it seemed better to leave that as a separate decision rather than fold it into a bug fix.

## Notes

- No API change, no behaviour change for any layer that actually changed.
- I checked open and closed PRs/issues first and did not find this covered.
- I did not touch `CHANGELOG.md`, since it looks like it is written at release-prep time and the most recent merged fix (#543) did not update it either — happy to add an entry if you would prefer one.